### PR TITLE
Avoid RC by borrowing Value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ name = "proto_refexp"
 debug = true
 
 [dependencies]
-serde = { version = "1.0.152", features = ["rc"] }
+serde = "1.0.152"
 serde_json = { version = "1.0.89", features = ["preserve_order"] }
 simd-json = "0.7.0"
 

--- a/src/expandable_value.rs
+++ b/src/expandable_value.rs
@@ -1,28 +1,27 @@
 use serde_json::Value;
-use std::rc::Rc;
 
 #[derive(Clone, Eq, PartialEq, Debug)]
-pub enum ExpandableValue {
-    Array(Vec<ExpandableValue>),
-    Object(Vec<(String, ObjectField)>),
+pub enum ExpandableValue<'a> {
+    Array(Vec<ExpandableValue<'a>>),
+    Object(Vec<(String, ObjectField<'a>)>),
     Other(Value),
 }
 
 #[derive(Clone, Eq, PartialEq, Debug)]
-pub enum ObjectField {
-    Field(ExpandableValue),
-    ExpandedReference(Rc<Value>),
+pub enum ObjectField<'a> {
+    Field(ExpandableValue<'a>),
+    ExpandedReference(&'a Value),
 }
 
-impl ExpandableValue {
-    pub fn as_array_mut(&mut self) -> Option<&mut Vec<ExpandableValue>> {
+impl<'a> ExpandableValue<'a> {
+    pub fn as_array_mut(&mut self) -> Option<&mut Vec<ExpandableValue<'a>>> {
         match self {
             ExpandableValue::Array(list) => Some(list),
             _ => None,
         }
     }
 
-    pub fn as_object_mut(&mut self) -> Option<&mut Vec<(String, ObjectField)>> {
+    pub fn as_object_mut(&mut self) -> Option<&mut Vec<(String, ObjectField<'a>)>> {
         match self {
             ExpandableValue::Object(map) => Some(map),
             _ => None,
@@ -35,7 +34,7 @@ mod tests {
     use crate::expandable_value::{ExpandableValue, ObjectField};
     use serde_json::Value;
 
-    impl From<Value> for ExpandableValue {
+    impl From<Value> for ExpandableValue<'_> {
         fn from(value: Value) -> Self {
             match value {
                 Value::Array(v) => {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,7 +1,7 @@
 use crate::expandable_value::{ExpandableValue, ObjectField};
 use serde::{Serialize, Serializer};
 
-impl Serialize for ExpandableValue {
+impl Serialize for ExpandableValue<'_> {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -22,7 +22,7 @@ impl Serialize for ExpandableValue {
     }
 }
 
-impl Serialize for ObjectField {
+impl Serialize for ObjectField<'_> {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
The performance is worse when using borrows instead of `Rc`.

<img width="956" alt="Screenshot 2023-01-03 at 17 37 10" src="https://user-images.githubusercontent.com/51669/210400505-4d501ba3-f6ab-4348-9091-749c9fec3a3a.png">
